### PR TITLE
Support for self-hosted plausible instance

### DIFF
--- a/pixel_plausible.php
+++ b/pixel_plausible.php
@@ -115,6 +115,14 @@ class Pixel_plausible extends Module
             return '';
         }
 
+        $plausible_instance_url = Configuration::get('PLAUSIBLE_INSTANCE_URL');
+
+        $this->context->smarty->assign(
+            [
+                'plausible_instance_url' => $plausible_instance_url,
+            ]
+        );
+
         return $this->fetch('module:pixel_plausible/views/templates/script.tpl');
     }
 
@@ -326,6 +334,19 @@ class Pixel_plausible extends Module
                 'default'  => 'order',
                 'desc' => $this->trans(
                     'Plausible goal name when customer submits order. Leave empty to ignore.',
+                    [],
+                    'Modules.Pixelplausible.Admin'
+                )
+            ],
+            'PLAUSIBLE_INSTANCE_URL' => [
+                'type'     => 'text',
+                'label'    => $this->trans('Plausible Instance URL', [], 'Modules.Pixelplausible.Admin'),
+                'name'     => 'PLAUSIBLE_INSTANCE_URL',
+                'size'     => 20,
+                'required' => true,
+                'default'  => 'https://plausible.io',
+                'desc' => $this->trans(
+                    'If you are using a dedicated instance for plausible. Don\'t change for plausible.io',
                     [],
                     'Modules.Pixelplausible.Admin'
                 )

--- a/src/Controller/Admin/PlausibleController.php
+++ b/src/Controller/Admin/PlausibleController.php
@@ -38,12 +38,16 @@ class PlausibleController extends FrameworkBundleAdminController
     public function statsAction(Request $request): Response
     {
         $sharedLink = (string)$this->config->getSharedLink();
+        $instanceUrl = (string)$this->config->getInstanceUrl();
+
+        $sharedLinkVerification = $instanceUrl . "/share";
 
         return $this->render(
             '@Modules/pixel_plausible/views/templates/admin/stats.html.twig',
             [
-                'sharedLink' => strpos($sharedLink, 'https://plausible.io/share') === 0 ? $sharedLink : '',
+                'sharedLink' => strpos($sharedLink, $sharedLinkVerification) === 0 ? $sharedLink : '',
                 'theme' => $this->config->getTheme(),
+                'plausible_instance_url' => $instanceUrl,
             ]
         );
     }

--- a/src/Helper/Config.php
+++ b/src/Helper/Config.php
@@ -27,6 +27,16 @@ class Config
      *
      * @return string|null
      */
+    public function getInstanceUrl(): ?string
+    {
+        return Configuration::get('PLAUSIBLE_INSTANCE_URL') ?: null;
+    }
+
+    /**
+     * Retrieve key
+     *
+     * @return string|null
+     */
     public function getTheme(): ?string
     {
         return Configuration::get('PLAUSIBLE_THEME') ?: null;

--- a/views/templates/admin/stats.html.twig
+++ b/views/templates/admin/stats.html.twig
@@ -4,7 +4,7 @@
     {% if sharedLink %}
     <iframe plausible-embed src="{{ sharedLink }}&embed=true&theme={{ theme ?: 'light' }}" scrolling="no" frameborder="0" loading="lazy" style="width: 1px; min-width: 100%; height: 1600px;"></iframe>
     <div style="font-size: 14px; padding-bottom: 14px;">Stats powered by <a target="_blank" style="color: #4F46E5; text-decoration: underline;" href="https://plausible.io">Plausible Analytics</a></div>
-    <script async src="https://plausible.io/js/embed.host.js"></script>
+    <script async src="{{ plausible_instance_url }}/js/embed.host.js"></script>
     {% else %}
     <p>{{ 'The "Shared link" is missing or is not a Plausible link. Update it in the module configuration.'|trans({}, 'Modules.Pixelplausible.Admin') }}</p>
     {% endif %}

--- a/views/templates/script.tpl
+++ b/views/templates/script.tpl
@@ -1,2 +1,2 @@
-<script defer data-domain="{$smarty.server.HTTP_HOST}" src="https://plausible.io/js/script.js"></script>
+<script defer data-domain="{$smarty.server.HTTP_HOST}" src="{$plausible_instance_url}/js/script.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>


### PR DESCRIPTION
Since it's possible to have a self-hosted instance of plausible, add a new configuration value for it.